### PR TITLE
fix: disable systemd service by default for flatpak compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xdg-desktop-portal (1.20.3+ds-1deepin1) unstable; urgency=medium
+
+  * fix: disable systemd service by default for flatpak compatibility
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 14 Jan 2025 11:05:04 +0100
+
 xdg-desktop-portal (1.20.3+ds-1) unstable; urgency=medium
 
   * New upstream stable release

--- a/debian/rules
+++ b/debian/rules
@@ -70,3 +70,12 @@ override_dh_fixperms:
 ifneq ($(filter %-tests,$(built_binaries)),)
 	chmod --recursive --changes a+rX,u+w,og-w debian/*-tests/usr/libexec/installed-tests
 endif
+
+# Disable xdg-desktop-portal-rewrite-launchers service by default
+# This service cleans up invalid launchers and rewrites sandboxed app launchers
+# Currently not required on deepin
+# 
+# Note: Disabling auto-start may affect Flatpak apps during system boot
+# Enable manually if needed.
+override_dh_installsystemduser:
+	dh_installsystemduser --name=xdg-desktop-portal-rewrite-launchers.service --no-enable


### PR DESCRIPTION
默认禁用 xdg-desktop-portal-rewrite-launchers 服务的自动启动，该服务用于在特定条件下清理无效的启动器文件以及特定条件下重写沙盒应用的启动器文件，主要应用场景为更新或者卸载flatpak应用，在deepin上默认不需要该服务，故暂时禁用自启动

注意：禁用自动启动后，无效的启动器需要手动清理，Flatpak 应用在系统启动时可能会受到影响（因为该服务未自动运行）

如有需要请手动启用

dh_installsystemd override to use --no-enable and --no-start flags for the xdg-desktop-portal-rewrite-launchers.service. This ensures the service is installed but not automatically enabled or started during package installation.

The service should only be enabled when installed via flatpak, not during regular Debian package installation. This prevents the service from running unnecessarily in non-flatpak environments and avoids potential conflicts or resource usage when the functionality isn't needed.

Influence:
1. Verify service is installed but disabled after package installation
2. Test that service doesn't start automatically on system boot
3. Confirm service can be manually enabled and started when needed
4. Check flatpak installation scenarios where service should be enabled
5. Verify no conflicts with existing xdg-desktop-portal services

fix: 默认禁用 systemd 服务以兼容 flatpak

修改 dh_installsystemd 覆盖规则，为 xdg-desktop-portal-rewrite- launchers.service 使用 --no-enable 和 --no-start 标志。这确保服务被安装 但不会在软件包安装期间自动启用或启动。

该服务应仅在通过 flatpak 安装时启用，而不是在常规 Debian 软件包安装期间
启用。这可以防止服务在非 flatpak 环境中不必要地运行，并避免在不需要该功
能时产生潜在冲突或资源使用。

Influence:
1. 验证软件包安装后服务已安装但处于禁用状态
2. 测试服务不会在系统启动时自动启动
3. 确认服务在需要时可以手动启用和启动
4. 检查 flatpak 安装场景，服务应在此场景下启用
5. 验证与现有 xdg-desktop-portal 服务无冲突

PMS: BUG-339551